### PR TITLE
Replace "RadioMediumObserver" with "RadioTransmissionObserver"

### DIFF
--- a/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java
+++ b/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java
@@ -83,7 +83,7 @@ public class RadioLoggerHeadless extends VisPlugin {
     simulation = simulationToControl;
     radioMedium = simulation.getRadioMedium();
 
-    radioMedium.addRadioMediumObserver(radioMediumObserver = new Observer() {
+    radioMedium.addRadioTransmissionObserver(radioMediumObserver = new Observer() {
       public void update(Observable obs, Object obj) {
         RadioConnection conn = radioMedium.getLastConnection();
         if (conn == null) {
@@ -102,7 +102,7 @@ public class RadioLoggerHeadless extends VisPlugin {
 
   public void closePlugin() {
     if (radioMediumObserver != null) {
-      radioMedium.deleteRadioMediumObserver(radioMediumObserver);
+      radioMedium.deleteRadioTransmissionObserver(radioMediumObserver);
     }
   }
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {


### PR DESCRIPTION
You fail to build cooja-radiologger-headless under the master branch
of contiki because of the refactoring of RadioMedium commited to
contiki/master on Aug 31, 2015. The short hash of the commit is
[c1a275f](https://github.com/contiki-os/contiki/commit/c1a275f0b2a9992f64f68a9fc84e2a2d83f67925).

Here is the error message in buidling the code.
````
 compile:
    [mkdir] Created dir: /home/user/contiki/tools/cooja/apps/radiologger-headless/build
    [javac] /home/user/contiki/tools/cooja/apps/radiologger-headless/build.xml:24: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 1 source file to /home/user/contiki/tools/cooja/apps/radiologger-headless/build
    [javac] /home/user/contiki/tools/cooja/apps/radiologger-headless/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java:86: error: cannot find symbol
    [javac]     radioMedium.addRadioMediumObserver(radioMediumObserver = new Observer() {
    [javac]                ^
    [javac]   symbol:   method addRadioMediumObserver(Observer)
    [javac]   location: variable radioMedium of type RadioMedium
    [javac] /home/user/contiki/tools/cooja/apps/radiologger-headless/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java:105: error: cannot find symbol
    [javac]       radioMedium.deleteRadioMediumObserver(radioMediumObserver);
    [javac]                  ^
    [javac]   symbol:   method deleteRadioMediumObserver(Observer)
    [javac]   location: variable radioMedium of type RadioMedium
    [javac] 2 errors
````
Two methods on which cooja-radiologger-headless depends,
"addRadioMediumObserver" and "deleteRadioMediumObserver, are
obsolete. They was changed to "addRadioTransmissionObserver" and
"deleteRadioTransmissionObserver" by the commit.

In order to follow the changes, the necessary string replacement was
made.