### PR TITLE
Apply the new pcapExporter.exportPacketData

### DIFF
--- a/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java
+++ b/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java
@@ -91,7 +91,8 @@ public class RadioLoggerHeadless extends VisPlugin {
         }
         RadioPacket radioPacket = conn.getSource().getLastPacketTransmitted();
         try {
-          pcapExporter.exportPacketData(radioPacket.getPacketData());
+          pcapExporter.exportPacketData(radioPacket.getPacketData(),
+                                        simulation.convertSimTimeToActualTime(conn.getStartTime()));
         } catch (IOException e) {
           System.err.println("Could not export pcap data");
           e.printStackTrace();

--- a/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java
+++ b/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java
@@ -76,9 +76,9 @@ public class RadioLoggerHeadless extends VisPlugin {
     super("Radio messages", cooja, false);
     System.err.println("Starting headless radio logger");
     try {
-        pcapExporter = new PcapExporter();
+      pcapExporter = new PcapExporter();
     } catch (IOException e) {
-        e.printStackTrace();
+      e.printStackTrace();
     }
     simulation = simulationToControl;
     radioMedium = simulation.getRadioMedium();
@@ -91,10 +91,10 @@ public class RadioLoggerHeadless extends VisPlugin {
         }
         RadioPacket radioPacket = conn.getSource().getLastPacketTransmitted();
         try {
-            pcapExporter.exportPacketData(radioPacket.getPacketData());
+          pcapExporter.exportPacketData(radioPacket.getPacketData());
         } catch (IOException e) {
-            System.err.println("Could not export pcap data");
-            e.printStackTrace();
+          System.err.println("Could not export pcap data");
+          e.printStackTrace();
         }
       }
     });
@@ -113,11 +113,11 @@ public class RadioLoggerHeadless extends VisPlugin {
         pcapFile = simulation.getCooja().restorePortablePath(new File(element.getText()));
         try {
           pcapExporter.openPcap(pcapFile);
-          } catch (IOException e) {
-            e.printStackTrace();
-          }
+        } catch (IOException e) {
+          e.printStackTrace();
         }
       }
+    }
     return true;
   }
 


### PR DESCRIPTION
Apply the newly introduced pcapExporter.exportPacketData.

The new pcapExporter.exportPacketData() has been introduced into Cooja by the commit of  contiki-os/contiki@728e417.

Further information is available at contiki-os/contiki#1502.

In addition, I made some changes on indentation.